### PR TITLE
Update super-linter.yml

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -29,3 +29,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FIX_JAVASCRIPT_ES: true
           FIX_JAVASCRIPT_PRETTIER: true
+          # Adding SQLFluff dialect
+          SQLFLUFF_DIALECT: postgres


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/super-linter.yml` file. The change adds the SQLFluff dialect configuration for PostgreSQL to the linter setup.

* [`.github/workflows/super-linter.yml`](diffhunk://#diff-3336387af05d3a6efeaa358d145494d23b6036f9034efe8ff6edca2522f06c33R32-R33): Added `SQLFLUFF_DIALECT` environment variable to specify PostgreSQL as the SQL dialect for SQLFluff.